### PR TITLE
Proposed camera view orientation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,4 @@ application on "localhost" - not just static files. To do that, either...
 * run `npm build` from the root of the client folder and have your own server serve the generated files.
 
 ## FUTURE TODOS:
-* Provide user feedback in camera mode.
 * Fix Camera when user alternates from portrait to landscape

--- a/client/src/CameraMark.js
+++ b/client/src/CameraMark.js
@@ -77,7 +77,7 @@ class CameraMark extends Component {
         //Default values
         let qHeight = 480;
         let qWidth = 640;
-        let qRatio = qHeight / qWidth;
+        let qRatio = qWidth / qHeight;
 
         let qTarget = document.querySelector('#scanner');
         let wWidth = qTarget.parentElement.clientWidth;
@@ -85,6 +85,19 @@ class CameraMark extends Component {
             qWidth = wWidth;
             qHeight = qWidth * qRatio;
         }
+
+        /* On android (not sure abuot IOS, I am unable to test on ios...), the Quaggar rotates
+         * the view port if the phone is in portrait mode. So I need to swap the height and width on android
+         * (again, not sure about ios...)
+         */
+        let isAndroid = /Android|webOS/i.test(navigator.userAgent);
+        let isUpright = window.orientation === 0 || window.orientation === 180;
+        if(isAndroid && isUpright) {
+            let tmp = qWidth;
+            qWidth = qHeight;
+            qHeight = tmp;
+        }
+
         Quagga.init({
             inputStream: {
                 name: 'Live',


### PR DESCRIPTION
When in the camera mode on android, I think the cameras with and height is generated from the perspective of the windows longest value. It assumes that when looking at the windows height and width, the longer value is the width. This isn't the case for android, so the view is actually flipped. This change should fix it.